### PR TITLE
macbook issue and oresat-dev fixes

### DIFF
--- a/docs/images.rst
+++ b/docs/images.rst
@@ -17,8 +17,10 @@ Notes about all images
 - Both eMMC0 and CAN1 device tree overlays are enabled.
 - Apt has both suggested and recommended autoinstall turned off.
 - All use `systemd-networkd`_ for networking.
-- The static IP address is 192.168.6.2 and will route internet from a host 
-  with an IP address of 192.168.6.1.
+- Has two staic IP address just like BeagleBoard's images; `192.168.6.2` (for
+  \*nix based) or `192.168.7.2` (for Windows).
+- Images will try to route internet from hosts an IP addresses of `192.168.6.1`
+  and  `192.168.7.1`.
 - The CAN1 bus is enabled.
 - The hostname is set to the name of board it's for; ie generic, star-tracker,
   etc.

--- a/images/README.rst
+++ b/images/README.rst
@@ -16,7 +16,7 @@ Set up
 
   .. code-block::
 
-    $ sudo apt install git device-tree-complier zstd
+    $ sudo apt install git zstd device-tree-compiler make cpp m4 gcc dosfstools kpartx wget parted
 
 - clone the oresat-linux repo
 
@@ -27,7 +27,8 @@ Set up
 Build Image
 -----------
 
-.. note:: On a pocketbeagle or a beagleboard black this will take >40 minutes
+.. note:: On a PocketBeagle or a BeagleBoard Black this will take ~40 minutes.
+   On a Raspberry Pi 3B it takes ~20 minutes.
 
 .. code-block::
 
@@ -36,7 +37,8 @@ Build Image
   
 where <board> can be
     - **cfc** - The image for OreSat's CFC (Cirrus Flux Camera) board.
-    - **dev** - A basic image for development. All other images are derived from this image.
+    - **dev** - A basic image for development. All other images are derived
+      from this image.
     - **dxwifi** - The image for the OreSat DxWiFi board.
     - **generic** - A generic image for custom OreSat boards.
     - **gps** - The image the OreSat's GPS board.

--- a/images/chroot_scripts/oresat-chroot.sh
+++ b/images/chroot_scripts/oresat-chroot.sh
@@ -8,7 +8,8 @@ echo "PermitRootLogin prohibit-password" >> /etc/ssh/sshd_config
 ##############################################################################
 echo "set default boot power mode"
 
-if [ hostname != "dev" ]; then
+HOSTNAME=`hostname`
+if [ $HOSTNAME != "dev" ]; then
 cat > "/etc/default/cpufrequtils" <<-__EOF__
 GOVERNOR="powersave"
 __EOF__
@@ -75,6 +76,6 @@ systemctl enable systemd-resolved
 ##############################################################################
 echo "remove internet packages required during build"
 
-if [ hostname != "dev" ]; then
+if [ $HOSTNAME != "dev" ]; then
 apt -y purge git git-man curl wget rsync
 fi

--- a/images/chroot_scripts/oresat-chroot.sh
+++ b/images/chroot_scripts/oresat-chroot.sh
@@ -34,18 +34,6 @@ echo "#USB Gadget Serial Port" >> /etc/securetty
 echo "ttyGS0" >> /etc/securetty
 
 ##############################################################################
-echo "setup usb ethernet"
-
-cat > "/etc/default/bb-boot" <<-__EOF__
-USB_NETWORK_DISABLED=yes
-USB_CONFIGURATION=enable
-__EOF__
-
-echo "g_ether" > /etc/modules-load.d/g_ether.conf
-HOST_ADDR=`dmesg | tr -s " " | grep "usb0: HOST MAC" | cut -d " " -f 6`
-echo "options g_ether host_addr=$HOST_ADDR" > /etc/modprobe.d/g_ether.conf
-
-##############################################################################
 echo "setup systemd-networkd"
 
 cat > "/etc/systemd/network/10-can.network" <<-__EOF__
@@ -56,9 +44,21 @@ Name=can1
 BitRate=1M
 __EOF__
 
-cat > "/etc/systemd/network/20-wired.network" <<-__EOF__
+cat > "/etc/systemd/network/20-wired-usb0.network" <<-__EOF__
 [Match]
 Name=usb0
+
+[Network]
+Address=192.168.7.2/24
+Gateway=192.168.7.1
+DNS=192.168.7.1
+DNS=8.8.8.8
+DNS=8.8.4.4
+__EOF__
+
+cat > "/etc/systemd/network/20-wired-usb1.network" <<-__EOF__
+[Match]
+Name=usb1
 
 [Network]
 Address=192.168.6.2/24
@@ -75,4 +75,6 @@ systemctl enable systemd-resolved
 ##############################################################################
 echo "remove internet packages required during build"
 
+if [ hostname != "dev" ]; then
 apt -y purge git git-man curl wget rsync
+fi


### PR DESCRIPTION
Images built will now use BeagleBoards usb-ethernet boot scripts again. This fixes the issue with macbooks not being able to connect easily to boards.

Also fixes a minor bug with hostname not being read correctly for the `oresat-dev` image exceptions.

closes #25 