### PR TITLE
Remove extraneous '.' at the start of the path

### DIFF
--- a/docs/images.rst
+++ b/docs/images.rst
@@ -55,7 +55,7 @@ Common changes to do on first boot
 
 - To expanded the image to use the entire SD card / eMMC run::
  
-    $ sudo ./opt/scripts/tools/grow_partition.sh
+    $ sudo /opt/scripts/tools/grow_partition.sh
     $ sudo reboot
 
 - Stop / disable OLM::


### PR DESCRIPTION
the grow_partition.sh script is located in the absolute path. The leading dot would only work if you were in the root directory.