### PR TITLE
GPIO SIM

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ OreSat Linux image builder and utilities.
 - **Image Builder:** Used to build OreSat Linux images.
 - **Octavo USB eMMC Flasher:** Used to flash a OreSat Linux card's eMMC over USB.
 - **Octavo EEPROM Flasher:** Used to flash a new OreSat Linux card's EEPROM.
+- **GPIO-SIM:** Used to setup simulated GPIO on development machines.
 
 ## OreSat Linux Images
 

--- a/gpio_sim/README.md
+++ b/gpio_sim/README.md
@@ -1,0 +1,29 @@
+# GPIO-SIM
+For working with the GPIO-SIM Linux Kernel
+
+## Setup
+
+### Build and install the linux Kernel from source
+- Debian
+```bash
+./kernel_build_debian.sh
+```
+### Add udev rules giving user permissions for GPIO
+```bash
+./gpio_rules.sh
+```
+## USE
+
+### Add simulated GPIO chips and lanes
+- Parses from the device-tree
+- Must be run on each boot, consider adding to ~/.bashrc
+```bash
+./setup_sims.sh
+```
+### remove simulated GPIO chips
+```bash
+./clean_sims.sh
+```
+
+
+

--- a/gpio_sim/README.md
+++ b/gpio_sim/README.md
@@ -1,5 +1,5 @@
 # GPIO-SIM
-For working with the GPIO-SIM Linux Kernel
+For working with Simulated GPIOs
 
 ## Setup
 

--- a/gpio_sim/clean_sims.sh
+++ b/gpio_sim/clean_sims.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2023 Kent Gibson <warthog618@gmail.com>
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+# A helper to remove any orphaned gpio-sims from the system.
+# This should only be necessary if a test was killed abnormally
+# preventing it from cleaning up the sims it created, or if you
+# created a sim using basic_sim.sh.
+
+SIMDIR="/sys/kernel/config/gpio-sim"
+find $SIMDIR -type d -name hog -exec rmdir '{}' '+'
+find $SIMDIR -type d -name "line*" -exec rmdir '{}' '+'
+find $SIMDIR -type d -name "bank*" -exec rmdir '{}' '+'
+rmdir $SIMDIR/*
+

--- a/gpio_sim/gpiod_rules.sh
+++ b/gpio_sim/gpiod_rules.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+sudo groupadd gpiod
+sudo usermod -aG gpiod $USER
+
+# This gives user permissions for all gpio.
+# Might want to change it to specific pins?
+
+echo '# udev rules for gpio port access through libgpiod
+SUBSYSTEM=="gpio", KERNEL=="gpiochip[0-4]", GROUP="gpiod", MODE="0660"' | sudo tee /etc/udev/rules.d/60-gpiod.rules

--- a/gpio_sim/kernel_build_debian.sh
+++ b/gpio_sim/kernel_build_debian.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# For Debian 
+# Build and install GPIO-SIM kernel module
+# Main reference https://www.debian.org/doc/manuals/debian-kernel-handbook/ch-common-tasks.html
+
+# Install prerequisites
+sudo apt-get update
+sudo apt-get -y install dpkg-dev
+sudo apt-get -y install build-essential fakeroot
+sudo apt-get -y build-dep linux
+
+# Get linux source
+sudo apt-get -y install linux-source
+
+# Get the directory of the sourced script
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+
+# Make the build directory
+BUILD_DIR=$SCRIPT_DIR/Kernel_Build
+mkdir -p $BUILD_DIR
+
+cd /usr/src
+# Find the latest version of the downloaded source
+SOURCE=$(ls | grep linux-source | sort -V | tail -n 1)
+
+# Extract the source
+tar xaf /usr/src/$SOURCE -C $BUILD_DIR
+
+# Get the version number (X.Y) from the source name
+VERSION=${SOURCE#linux-source-}
+VERSION=${VERSION%.tar.bz2}
+VERSION=${VERSION%.tar.xz}
+
+# Move into the source directory in the build directory
+cd $BUILD_DIR/linux-source-$VERSION
+
+# Build the Kernel
+MAKEFLAGS="-j$(nproc) LOCALVERSION=-gpio-sim CONFIG_GPIO_SIM=y"
+make clean
+make oldconfig # Combine this Kernel's configuration with the current running Kernel
+make deb-pkg $MAKEFLAGS
+
+# Move to the parent directory where the .deb files are located
+cd ..
+
+# Confirm before installing the kernel packages
+read -p "Are you sure you want to install the kernel packages? (y/n) " -n 1 -r
+echo    # (optional) move to a new line
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    sudo dpkg -i linux-image*.deb linux-headers*.deb
+    echo "Restart your machine to have the new build-in modules load on boot"
+fi

--- a/gpio_sim/setup_sims.sh
+++ b/gpio_sim/setup_sims.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Creates GPIO-SIM entries that match the device-tree configuration
+# described in FILE
+
+# Get the directory of the sourced script
+script_dir=$(dirname "${BASH_SOURCE[0]}")
+
+# The device tree file to parse
+FILE=$script_dir/../device_trees/oresat-c3-0601.dts
+
+mountpoint /sys/kernel/config > /dev/null || mount -t configfs configfs /sys/kernel/config
+
+# Initialize banks
+# 4 banks 32 gpio each
+dir=/sys/kernel/config/gpio-sim/basic
+for i in {0..3}
+do
+	mkdir -p $dir/bank$i
+	echo 32 > $dir/bank$i/num_lines
+done
+
+# Read the device tree file line by line
+while IFS= read -r line
+do
+	# Check if the line contains "gpio-name"
+	if [[ $line == *"gpio-name"* ]]; then
+	# Extract the gpio-name
+	gpio_name=$(echo $line | cut -d'"' -f 2)
+	echo "GPIO Name: $gpio_name"
+
+	read -r line
+	# Extract the gpiochip number and lane number
+	gpiochip_number=$(echo $line | cut -d' ' -f 3 | tr -dc '0-9')
+	lane_number=$(echo $line | cut -d' ' -f 4)
+	echo "GPIOCHIP Number: $gpiochip_number"
+	echo "Lane Number: $lane_number"
+
+	mkdir -p $dir/bank$gpiochip_number/line$lane_number
+	echo "$gpio_name" > $dir/bank$gpiochip_number/line$lane_number/name
+
+	# not setting direction becauase gpio-sim does not allow setting an initial direction
+	# Only when "hogging" the lane by the kernel it can set as input, output-high, and output-low
+	
+	# read -r line
+	## Extract the direction
+	# direction=$(echo $line | tr -d '[:space:]' | sed 's/;$//')
+	# echo "Direction: $direction"
+
+	#mkdir -p dir/bank$gpiochip_number/line$lane_number/hog/
+	#echo "hog-name-example" > $dir/bank$gpiochip_number/line$lane_number/hog/name
+	#echo "$direction" > $dir/bank$gpiochip_number/line$lane_number/hog/direction
+	#
+	fi
+
+done < "$FILE"
+
+echo 1 > $dir/live


### PR DESCRIPTION
- Script to build and install the Debian Linux kernel with the GPIO-SIM module support.
- Script to parse the C3 device-tree and setup matching simulated GPIO on a development machine.
- Script to tear down the simulated GPIO.
- Script to give user permissions to the simulated GPIO.