### PR TITLE
Fixes device tree compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 # Kconfig .old
 *.old
 
-# Repos
-BeagleBoard-DeviceTrees/
-
 # Python
 __pycache__/
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "image_builder/image-builder"]
 	path = image_builder/image-builder
 	url = https://github.com/RobertCNelson/omap-image-builder.git
+[submodule "device_trees/BeagleBoard-DeviceTrees"]
+	path = device_trees/BeagleBoard-DeviceTrees
+	url = https://github.com/beagleboard/BeagleBoard-DeviceTrees.git

--- a/device_trees/Makefile
+++ b/device_trees/Makefile
@@ -2,21 +2,20 @@ SOURCES = $(wildcard *.dts)
 DTBS = $(SOURCES:%.dts=%.dtb)
 
 REPO = BeagleBoard-DeviceTrees
+SRC_PATH = src/arm/ti/omap
 
 .PHONY: all clean clone
 
 all: clone $(DTBS)
 
+# copy all dtsi files into the source directory
 clone:
-	@if [ ! -d $(REPO) ]; then \
-		git clone https://github.com/beagleboard/$(REPO); \
-	fi
-	@cp $(wildcard *.dtsi) $(REPO)/src/arm/
+	@cp $(wildcard *.dtsi) $(REPO)/$(SRC_PATH)
 
 %.dtb: %.dts
-	@cp $< $(REPO)/src/arm/
-	make -C $(REPO) src/arm/$@
-	@cp $(REPO)/src/arm/$@ .
+	@cp $< $(REPO)/$(SRC_PATH)/
+	make -C $(REPO) $(SRC_PATH)/$@
+	@cp $(REPO)/$(SRC_PATH)/$@ .
 
 clean:
 	rm -f *.dtb

--- a/device_trees/Makefile
+++ b/device_trees/Makefile
@@ -4,19 +4,20 @@ DTBS = $(SOURCES:%.dts=%.dtb)
 REPO = BeagleBoard-DeviceTrees
 SRC_PATH = src/arm/ti/omap
 
-.PHONY: all clean clone
+.PHONY: all clean copy-to-repo
 
-all: clone $(DTBS)
+all: copy-to-repo $(DTBS)
 
 # copy all dtsi files into the source directory
-clone:
+copy-to-repo:
 	@cp $(wildcard *.dtsi) $(REPO)/$(SRC_PATH)
 
 %.dtb: %.dts
 	@cp $< $(REPO)/$(SRC_PATH)/
 	make -C $(REPO) $(SRC_PATH)/$@
-	@cp $(REPO)/$(SRC_PATH)/$@ .
+	@mv $(REPO)/$(SRC_PATH)/$@ .
 
 clean:
 	rm -f *.dtb
+	rm -f $(REPO)/$(SRC_PATH)/oresat-*
 	make -C $(REPO) clean

--- a/device_trees/oresat-base.dtsi
+++ b/device_trees/oresat-base.dtsi
@@ -260,11 +260,6 @@ LED pins, and the power regulator. All other pins are set to GPIO inputs.
   status = "disabled";
 };
 
-/* 3d graphics accelerator */
-&gpu {
-  status = "disabled";
-};
-
 /* LCD controller */
 &lcdc {
   status = "disabled";


### PR DESCRIPTION
When I found the oresat-linux repo device trees wouldn't compile because the structure of the beagleboard device trees repo had changed. 

Removes unused gpu label from oresat-base.dtsi
Changes Makefile to reflect change in BeagleBoard-DeviceTrees structure
Adds BeagleBoard-DeviceTrees as a submodule
