### PR TITLE
Add Github actions for linting and compile checking

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,57 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  tests:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        submodules: true
+
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y shellcheck device-tree-compiler
+
+    - name: Shellcheck scripts
+      run: |
+        # All shell scripts that aren't in submodules
+        find -type f -name '*.sh' \
+          -not -path './device_trees/BeagleBoard-DeviceTrees/*' \
+          -not -path './image_builder/image-builder/*' \
+          -not -path './image_builder/u-boot/*' \
+        | xargs shellcheck
+
+    - name: Build device trees
+      run: |
+        make -C device_trees
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.11"
+        cache: "pip"
+
+    - name: Install Python dependencies
+      working-directory: ./octavo_eeprom_flasher
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install . --group dev
+
+    - name: Run Python lints
+      working-directory: ./octavo_eeprom_flasher
+      run: |
+        ruff check
+        ruff format --check --diff
+        mypy eeprom.py

--- a/image_builder/chroot_scripts/oresat-early-chroot.sh
+++ b/image_builder/chroot_scripts/oresat-early-chroot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 # NOTE:
 # The early chroot script is, counterintuitively, really a pre-chroot hook.

--- a/image_builder/scripts/grow_partition.sh
+++ b/image_builder/scripts/grow_partition.sh
@@ -1,17 +1,18 @@
-#/bin/bash -e
+#!/bin/bash -e
 
 if [ $# -eq 0 ]; then
-    mounted_root_parition=`lsblk | grep "/" | cut -d " " -f 1 | tr -cd "[:alnum:]"`
-elif [ $1 == "-h" ] || [ $1 == "--help" ]; then
+    mounted_root_partition=$(df --output=source / | grep /dev)
+elif [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
     echo "Will grow the root parition to use all available space"
     echo "Usage: $0 <root parition>"
     echo "If no root parition is given, the mounted root parition will be expaned"
     echo "example: $0 /dev/mmcblk0p2"
     exit 0
 else
-    mounted_root_parition=`echo $1 | rev | cut -d "/" -f 1 | rev`
+    mounted_root_partition=$1
 fi
 
-growpart_args=`echo $mounted_root_parition | sed -e "s/p/ /g"`
-sudo growpart /dev/$growpart_args
-sudo resize2fs /dev/$mounted_root_parition
+mounted_root_partition=$(basename "$mounted_root_partition")
+growpart_args=${mounted_root_partition//p/" "}
+sudo growpart "/dev/$growpart_args"
+sudo resize2fs "/dev/$mounted_root_partition"

--- a/image_builder/scripts/print_eeprom.sh
+++ b/image_builder/scripts/print_eeprom.sh
@@ -1,46 +1,48 @@
-#/bin/bash -e
+#!/bin/bash -e
 
-raw=`sudo cat /sys/bus/i2c/devices/*/eeprom | cut -c 5-28`
+raw=$(sudo cut -c 5-28 /sys/bus/i2c/devices/*/eeprom)
 echo "Raw: $raw"
 
 is_oresat_card=1
-board_id=`echo $raw | cut -c 1-8`
-if [ $board_id = "A335OSC3" ]; then
-  name="C3"
-elif [ $board_id = "A335OCFC" ]; then
-  name="CFC"
-elif [ $board_id = "A335ODWF" ]; then
-  name="DxWiFi"
-elif [ $board_id = "A335OGPS" ]; then
-  name="GPS"
-elif [ $board_id = "A335OSST" ]; then
-  name="Star Tracker"
-elif [ $board_id = "A335PBGL" ]; then
-  name="PocketBeagle"
-  is_oresat_card=0
-elif [ $board_id = "A335BNLT" ]; then
-  name="BeagleBone Black"
-  is_oresat_card=0
-else
-  name="Unknown"
-  is_oresat_card=0
-fi
+board_id=$(cut -c 1-8 <<< "$raw")
+
+case "$board_id" in
+  "A335OSC3")
+    name="C3";;
+  "A335OCFC")
+    name="CFC";;
+  "A335ODWF")
+    name="DxWiFi";;
+  "A335OGPS")
+    name="GPS";;
+  "A335OSST")
+    name="Star Tracker";;
+  "A335PBGL")
+    name="PocketBeagle"
+    is_oresat_card=0;;
+  "A335BNLT")
+    name="BeagleBone Black"
+    is_oresat_card=0;;
+  *)
+    name="Unknown"
+    is_oresat_card=0;;
+esac
 echo "Board: $name ($board_id)"
 
 
-version=`echo $raw | cut -c 9-12`
+version=$(cut -c 9-12 <<< "$raw")
 if [ $is_oresat_card -eq 1 ]; then
-  maj_version=`echo $raw | cut -c 9-10 | sed -r "s/0([0-9A-F]*)/\1/"`
-  min_version=`echo $raw | cut -c 11-12 | sed -r "s/0([0-9A-F]*)/\1/"`
+  maj_version=$(cut -c 9-10 <<< "$raw" | sed -r "s/0([0-9A-F]*)/\1/")
+  min_version=$(cut -c 11-12 <<< "$raw" | sed -r "s/0([0-9A-F]*)/\1/")
   echo "Version: $maj_version.$min_version ($version)"
 else
   echo "Version: $version"
 fi
 
-week=`echo $raw | cut -c 13-14`
-year=`echo $raw | cut -c 15-16`
+week=$(cut -c 13-14 <<< "$raw")
+year=$(cut -c 15-16 <<< "$raw")
 echo "Manufacture Year: $year"
 echo "Manufacture Week: $week"
 
-card_id=`echo $raw | cut -c 21-24 | sed -r "s/0*([0-9A-F]*)/\1/"`
+card_id=$(cut -c 21-24 <<< "$raw" | sed -r "s/0*([0-9A-F]*)/\1/")
 echo "Card ID: $card_id"

--- a/image_builder/scripts/vcan.sh
+++ b/image_builder/scripts/vcan.sh
@@ -1,3 +1,3 @@
-#/bin/bash -e
+#!/bin/bash -e
 sudo ip link add dev vcan0 type vcan
 sudo ip link set vcan0 up

--- a/image_builder/scripts/write_uboot.sh
+++ b/image_builder/scripts/write_uboot.sh
@@ -2,5 +2,5 @@
 
 DEVICE=$1
 
-dd if=u-boot-dtb.img of=${DEVICE} count=4 seek=1 bs=384k
-dd if=MLO of=${DEVICE} count=2 seek=1 bs=128k
+dd if=u-boot-dtb.img of="${DEVICE}" count=4 seek=1 bs=384k
+dd if=MLO of="${DEVICE}" count=2 seek=1 bs=128k

--- a/octavo_eeprom_flasher/pyproject.toml
+++ b/octavo_eeprom_flasher/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "python-periphery >= 2.4.1",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "mypy >= 1.19.1",
     "ruff >= 0.15.0",


### PR DESCRIPTION
With 68d5a5 introducing shellcheck directives and eeprom-flasher getting ruff and mypy I figured it's time to add actions that check these automatically. This isn't a complete list of checks we could do and notably this isn't running the image builder itself since that's expensive. This also doesn't fix any of the shellcheck lints its failing on, that'll come in the next commit.