### PR TITLE
Overhaul oresat-early-chroot

### DIFF
--- a/image_builder/chroot_scripts/oresat-early-chroot.sh
+++ b/image_builder/chroot_scripts/oresat-early-chroot.sh
@@ -1,29 +1,34 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
-TEMPDIR=$(grep -i tempdir= .project | cut -d "=" -f 2 | sed 's/\"//g')
-HOSTNAME=$(grep -i hostname= .project | cut -d "=" -f 2 | sed 's/\"//g')
+# NOTE:
+# The early chroot script is, counterintuitively, really a pre-chroot hook.
+# It allows for passing information *into* the build target (tempdir).
+# After this script, the build context will be inaccessible to the target.
+
+# the path to tempdir is passed as an argument by the omap image builder
+tempdir=$1
 
 # to remove install installing recommended and suggestes packages
 # note image-builder removes this file during cleanup
-cat >"${TEMPDIR}/etc/apt/apt.conf" <<-__EOF__
+cat >"${tempdir}/etc/apt/apt.conf" <<-__EOF__
 APT::Install-Suggests "0";
 APT::Install-Recommends "0";
 __EOF__
 
 # add oresat debian repo
-echo "deb [trusted=yes] https://debian.oresat.org/debian/ ./" >>${TEMPDIR}/etc/apt/sources.list
+echo "deb [trusted=yes] https://debian.oresat.org/debian/ ./" >>"${tempdir}/etc/apt/sources.list"
 apt update
 
 # add this to use piwheels.org as an extra source
 # piwheels.org has pre-built "manylinux" armhf packages
 # otherwise packages like numpy, psutil, and opencv-python have to be build from pypi source
-cat >"${TEMPDIR}/etc/pip.conf" <<-__EOF__
+cat >"${tempdir}/etc/pip.conf" <<-__EOF__
 [global]
 extra_index_url = https://piwheels.org/simple
 __EOF__
 
 # add all oresat device trees to /tmp
-cp ../../device_trees/*.dtb $TEMPDIR/tmp
+cp -v ../../device_trees/*.dtb "${tempdir}"/tmp
 
 # add custom scripts
-cp -r ../scripts $TEMPDIR/opt
+cp -vr ../scripts "${tempdir}"/opt

--- a/image_builder/chroot_scripts/oresat-early-chroot.sh
+++ b/image_builder/chroot_scripts/oresat-early-chroot.sh
@@ -17,7 +17,6 @@ __EOF__
 
 # add oresat debian repo
 echo "deb [trusted=yes] https://debian.oresat.org/debian/ ./" >>"${tempdir}/etc/apt/sources.list"
-apt update
 
 # add this to use piwheels.org as an extra source
 # piwheels.org has pre-built "manylinux" armhf packages


### PR DESCRIPTION
Updates formatting and uses tempdir as an argument passed from the omap image builder.