### PR TITLE
update image build tooling

### DIFF
--- a/image_builder/build_images.sh
+++ b/image_builder/build_images.sh
@@ -3,47 +3,39 @@
 list="c3 cfc dev dxwifi generic gps star-tracker"
 
 if [[ ! $list =~ (^|[[:space:]])$1($|[[:space:]]) ]]; then
-    echo "Invalid board argument"
-    echo ""
-    echo "./build_images.sh <BOARD>"
-    echo ""
-    echo "where <BOARD> can be:"
-    for i in $list; do
-        echo "  $i"
-    done
-    exit 1
+  echo "Invalid board argument"
+  echo ""
+  echo "./build_images.sh <BOARD>"
+  echo ""
+  echo "where <BOARD> can be:"
+  for i in $list; do
+    echo "  $i"
+  done
+  exit 1
 fi
 
-BOARD="oresat-"$1
-DATE=`date "+%F"`
-NAME="$BOARD-$DATE"
-SIZE="2gb"
+DIR="$PWD"
 
-if [ $BOARD == "oresat-dev" ]; then
-    SIZE="4gb"
+board="oresat-"$1
+date=$(date "+%F")
+name="${board}-${date}"
+size="2gb"
+
+if [ "${board}" == "oresat-dev" ]; then
+  size="4gb"
 fi
 
-BOOTLOADER_DIR="u-boot"
-SPL="MLO"
-BOOTLOADER="u-boot-dtb.img"
-DTB="oresat-bootloader"
-IMAGE_DIR="images"
-
-SETUP_SDCARD_EXTRA_ARGS=" \
-    --spl $BOOTLOADER_DIR/$SPL \
-    --bootloader $BOOTLOADER_DIR/$BOOTLOADER \
-"
-
-if [ $BOARD != "oresat-dev" ] && [ $BOARD != "oresat-generic" ]; then
-    SETUP_SDCARD_EXTRA_ARGS="--enable-uboot-disable-pru ${SETUP_SDCARD_EXTRA_ARGS}"
-fi
-
-echo "setup_sdcard.sh options: $SETUP_SDCARD_EXTRA_ARGS"
+bootloader_dir="u-boot"
+spl="MLO"
+bootloader="u-boot-dtb.img"
+dtb="oresat-bootloader"
+image_dir="images"
 
 # copy oresat config into correct dirs
-cp ./configs/$BOARD.conf ./image-builder/configs/
-cp ./configs/$DTB.conf ./image-builder/tools/hwpack
-cp ./chroot_scripts/*.sh ./image-builder/target/chroot/
+cp -v configs/"${board}".conf image-builder/configs
+cp -v configs/"${dtb}".conf image-builder/tools/hwpack
+cp -v chroot_scripts/oresat-chroot.sh image-builder/target/chroot
+cp -v chroot_scripts/oresat-early-chroot.sh image-builder/target/chroot
 
 cd image-builder
 
@@ -51,22 +43,25 @@ cd image-builder
 rm -rf deploy
 
 # build partitions
-./RootStock-NG.sh -c $BOARD
+/bin/bash -e RootStock-NG.sh -c "${board}"
 
 cd deploy/debian-*/
-cp ../../../$BOOTLOADER_DIR/{$SPL,$BOOTLOADER} ./u-boot
+cp -v "${DIR}/scripts/post_build.sh" .
+cp -v "${DIR}/configs/genimage.cfg" .
+cp -v "${DIR}/${bootloader_dir}/${spl}" .
+cp -v "${DIR}/${bootloader_dir}/${bootloader}" .
 
 # make .img file
-sudo ./setup_sdcard.sh --img-$SIZE $NAME.img --dtb $DTB $SETUP_SDCARD_EXTRA_ARGS
+sudo /bin/bash -e post_build.sh
 
 # compress
-zstd $NAME-$SIZE.img
+mv images/sdcard.img "${name}-${size}.img"
+zstd "${name}-${size}.img"
 
-cd ../../..
+mkdir -p "${DIR}/${image_dir}"
 
-mkdir -p $IMAGE_DIR
-
-mv image-builder/deploy/debian-*/$NAME-$SIZE.img.zst $IMAGE_DIR
+mv "${name}-${size}.img.zst" "${DIR}/${image_dir}"
+cd "${DIR}/${image_dir}"
 
 # generate sha256
-sha256sum $IMAGE_DIR/$NAME-$SIZE.img.zst > $IMAGE_DIR/$NAME-$SIZE.img.zst.sha256
+sha256sum "${name}-${size}.img.zst" >"${name}-${size}.img.zst.sha256"

--- a/image_builder/build_images.sh
+++ b/image_builder/build_images.sh
@@ -52,13 +52,17 @@ cp -v "${DIR}/${bootloader_dir}/${spl}" .
 cp -v "${DIR}/${bootloader_dir}/${bootloader}" .
 
 # make .img file
-sudo /bin/bash -e post_build.sh
+/bin/bash -e post_build.sh
 
 # compress
 mv images/sdcard.img "${name}-${size}.img"
 zstd "${name}-${size}.img"
 
 mkdir -p "${DIR}/${image_dir}"
+
+# give ownership to non-root users
+chgrp --recursive users "${DIR}/${image_dir}"
+chmod --recursive g+w "${DIR}/${image_dir}"
 
 mv "${name}-${size}.img.zst" "${DIR}/${image_dir}"
 cd "${DIR}/${image_dir}"

--- a/image_builder/configs/genimage.cfg
+++ b/image_builder/configs/genimage.cfg
@@ -1,0 +1,40 @@
+#genimage.cfg
+image sdcard.img {
+        hdimage {
+                partition-table-type = "mbr"
+        }
+        partition MLO {
+                in-partition-table = "no"
+                image = "MLO"
+                offset = 128K
+        }
+        partition u-boot {
+                in-partition-table = "no"
+                image = "u-boot-dtb.img"
+                offset = 384K
+        }
+        partition boot {
+                bootable = "true"
+                partition-type = 0xc
+                image = "boot.vfat"
+                offset = 4M
+        }
+        partition rootfs {
+                partition-type = 0x83
+                image = "rootfs.ext4"
+        }
+}
+image boot.vfat {
+        size = 36M
+        vfat {
+                label = "BOOT"
+        }
+        mountpoint = "fs-bootfs"
+}
+image rootfs.ext4 {
+        size = "120%"
+        ext4 {
+                label = "rootfs"
+        }
+        mountpoint = "fs-rootfs"
+}

--- a/image_builder/scripts/post_build.sh
+++ b/image_builder/scripts/post_build.sh
@@ -5,10 +5,15 @@ if [ "$(id -u)" != "0" ]; then
   exit 1
 fi
 
-DIR="$PWD"
-target_dir="${DIR}/fs"
-root_fs="${DIR}/fs/fs-rootfs"
-boot_fs="${DIR}/fs/fs-bootfs"
+target_dir="fs"
+root_fs="fs/fs-rootfs"
+boot_fs="fs/fs-bootfs"
+
+# these are supplied by the project config file
+rfs_username=""
+rfs_password=""
+rfs_hostname=""
+config_path="./image-builder.project"
 
 # load build configuration
 # exit if not present
@@ -17,18 +22,19 @@ if [ ! -f image-builder.project ]; then
   exit 1
 fi
 
-. "${DIR}image-builder.project"
+# shellcheck source=./image-builder.project
+. "${config_path}"
 
 mkdir -p "${target_dir}"
 
-if [ ! -f "${DIR}/MLO" ]; then
+if [ ! -f "MLO" ]; then
   echo "ERROR: (post-build) MLO missing"
   exit 1
 fi
 
 cp -v MLO "${target_dir}"
 
-if [ ! -f "${DIR}/u-boot-dtb.img" ]; then
+if [ ! -f "u-boot-dtb.img" ]; then
   echo "ERROR: (post-build) u-boot-dtb.img missing"
   exit 1
 fi
@@ -44,7 +50,7 @@ kernel_select() {
   echo "debug: kernel_select: picking the first available kernel..."
   unset check
   check=$(ls "${dir_check}" | grep vmlinuz- | head -n 1)
-  if [ "x${check}" != "x" ]; then
+  if [ "${check}" != "" ]; then
     kernel_version=$(ls "${dir_check}" | grep vmlinuz- | head -n 1 | awk -F'vmlinuz-' '{print $2}')
     echo "debug: kernel_select: found: [${kernel_version}]"
   else
@@ -90,7 +96,7 @@ LABEL linux
   APPEND console=ttyS0,115200 root=/dev/mmcblk0p2 rw rootwait
 __EOF__
 
-if [ ! -f ${DIR}/genimage.cfg ]; then
+if [ ! -f ./genimage.cfg ]; then
   echo "ERROR: (post-build) genimage configuration missing"
   exit 1
 fi

--- a/image_builder/scripts/post_build.sh
+++ b/image_builder/scripts/post_build.sh
@@ -8,6 +8,7 @@ fi
 target_dir="fs"
 root_fs="fs/fs-rootfs"
 boot_fs="fs/fs-bootfs"
+fdt=""
 
 # these are supplied by the project config file
 rfs_username=""
@@ -24,6 +25,9 @@ fi
 
 # shellcheck disable=SC1090
 . "${config_path}"
+
+# enable nullglob
+shopt -s nullglob
 
 mkdir -p "${target_dir}"
 
@@ -48,10 +52,9 @@ tar xf armhf-rootfs-debian-*.tar -C "${root_fs}"
 dir_check="${root_fs}/boot"
 kernel_select() {
   echo "debug: kernel_select: picking the first available kernel..."
-  unset check
-  check=$(ls "${dir_check}" | grep vmlinuz- | head -n 1)
-  if [ "${check}" != "" ]; then
-    kernel_version=$(ls "${dir_check}" | grep vmlinuz- | head -n 1 | awk -F'vmlinuz-' '{print $2}')
+  check=("${dir_check}"/vimlinuz*)
+  if [ "${check[0]}" != "" ]; then
+    kernel_version="${check[0]#vmlinuz-}"
     echo "debug: kernel_select: found: [${kernel_version}]"
   else
     echo "ERROR: no installed kernel"
@@ -77,24 +80,31 @@ __EOF__
 cp -v "${root_fs}/boot/vmlinuz-${kernel_version}" "${boot_fs}"
 cp -v "${root_fs}/boot/initrd.img-${kernel_version}" "${boot_fs}"
 
-# TODO: update this portion to match board name
 echo "Log: (post-build) copying fdt"
 mkdir -p "${boot_fs}/dtbs/${kernel_version}"
-cp -v "${root_fs}/boot/dtbs/${kernel_version}/am335x-boneblack.dtb" "${boot_fs}/dtbs/${kernel_version}/"
+
+if [ "${rfs_hostname}" != "oresat-dev" ]; then
+  dtbs=("${root_fs}/boot/dtbs/${kernel_version}/${rfs_hostname}"-*.dtb)
+
+  # select the latest dtb, strip directory and suffix
+  fdt=$(basename "${dtbs[-1]}")
+else
+  fdt="am335x-pocketbeagle.dtb"
+fi
 
 echo "Log: (post-build) configuring extlinux"
-mkdir -p "${boot_fs}/extlinux"
+cp -v "${root_fs}/boot/dtbs/${kernel_version}/${fdt}" "${boot_fs}/dtbs/${kernel_version}"
 
-#HereDoc to write extlinux configuration
+mkdir -p "${boot_fs}/extlinux"
 cat <<__EOF__ >"${boot_fs}/extlinux/extlinux.conf"
 TIMEOUT 1
 DEFAULT linux
 
 LABEL linux
-  KERNEL /vmlinuz-${kernel_version}
-  INITRD /initrd.img-${kernel_version}
-  FDT /dtbs/${kernel_version}/am335x-boneblack.dtb
-  APPEND console=ttyS0,115200 root=/dev/mmcblk0p2 rw rootwait
+KERNEL /vmlinuz-${kernel_version}
+INITRD /initrd.img-${kernel_version}
+FDT /dtbs/${kernel_version}/${fdt}
+APPEND console=ttyS0,115200 root=/dev/mmcblk0p2 rw rootwait
 __EOF__
 
 if [ ! -f ./genimage.cfg ]; then

--- a/image_builder/scripts/post_build.sh
+++ b/image_builder/scripts/post_build.sh
@@ -22,7 +22,7 @@ if [ ! -f image-builder.project ]; then
   exit 1
 fi
 
-# shellcheck source=./image-builder.project
+# shellcheck disable=SC1090
 . "${config_path}"
 
 mkdir -p "${target_dir}"
@@ -43,7 +43,7 @@ cp -v u-boot-dtb.img "${target_dir}"
 
 echo "Log: (post-build) building root fs"
 mkdir -p "${root_fs}"
-tar xf armhf-rootfs-debian-bullseye.tar -C "${root_fs}"
+tar xf armhf-rootfs-debian-*.tar -C "${root_fs}"
 
 dir_check="${root_fs}/boot"
 kernel_select() {
@@ -77,6 +77,7 @@ __EOF__
 cp -v "${root_fs}/boot/vmlinuz-${kernel_version}" "${boot_fs}"
 cp -v "${root_fs}/boot/initrd.img-${kernel_version}" "${boot_fs}"
 
+# TODO: update this portion to match board name
 echo "Log: (post-build) copying fdt"
 mkdir -p "${boot_fs}/dtbs/${kernel_version}"
 cp -v "${root_fs}/boot/dtbs/${kernel_version}/am335x-boneblack.dtb" "${boot_fs}/dtbs/${kernel_version}/"

--- a/image_builder/scripts/post_build.sh
+++ b/image_builder/scripts/post_build.sh
@@ -1,0 +1,98 @@
+#!/bin/bash -e
+
+if [ "$(id -u)" != "0" ]; then
+  echo "Log: (post-build) need to be root"
+  exit 1
+fi
+
+DIR="$PWD"
+target_dir="${DIR}/fs"
+root_fs="${DIR}/fs/fs-rootfs"
+boot_fs="${DIR}/fs/fs-bootfs"
+
+# load build configuration
+# exit if not present
+if [ ! -f image-builder.project ]; then
+  echo "ERROR: (post-build) missing .project configuration"
+  exit 1
+fi
+
+. "${DIR}image-builder.project"
+
+mkdir -p "${target_dir}"
+
+if [ ! -f "${DIR}/MLO" ]; then
+  echo "ERROR: (post-build) MLO missing"
+  exit 1
+fi
+
+cp -v MLO "${target_dir}"
+
+if [ ! -f "${DIR}/u-boot-dtb.img" ]; then
+  echo "ERROR: (post-build) u-boot-dtb.img missing"
+  exit 1
+fi
+
+cp -v u-boot-dtb.img "${target_dir}"
+
+echo "Log: (post-build) building root fs"
+mkdir -p "${root_fs}"
+tar xf armhf-rootfs-debian-bullseye.tar -C "${root_fs}"
+
+dir_check="${root_fs}/boot"
+kernel_select() {
+  echo "debug: kernel_select: picking the first available kernel..."
+  unset check
+  check=$(ls "${dir_check}" | grep vmlinuz- | head -n 1)
+  if [ "x${check}" != "x" ]; then
+    kernel_version=$(ls "${dir_check}" | grep vmlinuz- | head -n 1 | awk -F'vmlinuz-' '{print $2}')
+    echo "debug: kernel_select: found: [${kernel_version}]"
+  else
+    echo "ERROR: no installed kernel"
+    exit
+  fi
+}
+
+# get the first available kernel
+kernel_select
+
+# set up uenv
+echo "Log: (post-build) building boot fs"
+echo "uname_r=${kernel_version}" >>"${root_fs}/boot/uEnv.txt"
+echo "cmdline=fsck.repair=yes earlycon net.ifnames=0" >>"${root_fs}/boot/uEnv.txt"
+
+mkdir -p "${boot_fs}"
+cat <<__EOF__ >"${boot_fs}/sysconf.txt"
+user_name="${rfs_username}"
+user_password="${rfs_password}"
+hostname="${rfs_hostname}"
+__EOF__
+
+cp -v "${root_fs}/boot/vmlinuz-${kernel_version}" "${boot_fs}"
+cp -v "${root_fs}/boot/initrd.img-${kernel_version}" "${boot_fs}"
+
+echo "Log: (post-build) copying fdt"
+mkdir -p "${boot_fs}/dtbs/${kernel_version}"
+cp -v "${root_fs}/boot/dtbs/${kernel_version}/am335x-boneblack.dtb" "${boot_fs}/dtbs/${kernel_version}/"
+
+echo "Log: (post-build) configuring extlinux"
+mkdir -p "${boot_fs}/extlinux"
+
+#HereDoc to write extlinux configuration
+cat <<__EOF__ >"${boot_fs}/extlinux/extlinux.conf"
+TIMEOUT 1
+DEFAULT linux
+
+LABEL linux
+  KERNEL /vmlinuz-${kernel_version}
+  INITRD /initrd.img-${kernel_version}
+  FDT /dtbs/${kernel_version}/am335x-boneblack.dtb
+  APPEND console=ttyS0,115200 root=/dev/mmcblk0p2 rw rootwait
+__EOF__
+
+if [ ! -f ${DIR}/genimage.cfg ]; then
+  echo "ERROR: (post-build) genimage configuration missing"
+  exit 1
+fi
+
+genimage --rootpath "${target_dir}" --inputpath "${target_dir}" --config genimage.cfg


### PR DESCRIPTION
Cherry-picks commits from experimental-debian-13-img-builder to extract `post-build.sh`, `genimage.cfg`, and changes to `build-image.sh`. 

- `genimage.cfg` is a declarative configuration file used by `genimage` to create a bootable image
    - It specifies the partition configuration, and where to place the bootloader
- `post-build.sh` is called after chroot to create a bootable image (w/ `genimage`) and build boot configuration (`extlinux.conf`)

#### Commits 

- **Adds scripts and configuration for post-build**
- **Tie in `build_images.sh` and `post_build.sh`**
- **Make post-build suite generic**
- **Catch board specific FDTs**
