### PR TITLE
Adds rules to ignore untracked content

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,8 @@
 [submodule "image_builder/image-builder"]
 	path = image_builder/image-builder
 	url = https://github.com/RobertCNelson/omap-image-builder.git
+  	ignore = untracked
 [submodule "device_trees/BeagleBoard-DeviceTrees"]
 	path = device_trees/BeagleBoard-DeviceTrees
 	url = https://github.com/beagleboard/BeagleBoard-DeviceTrees.git
+  	ignore = untracked

--- a/image_builder/Makefile
+++ b/image_builder/Makefile
@@ -25,8 +25,10 @@ u-boot/README image-builder/readme.md:
 	$(error $(dir $@) not initialized. Hint: git submodule update --init)
 
 clean:
+	make clean -C ../device_trees
+	make mrproper -C u-boot
 	rm -f image-builder/configs/oresat*
 	rm -f image-builder/target/chroot/oresat*
 	rm -f image-builder/tools/hwpack/oresat-bootloader.conf
-	make mrproper -C u-boot
-	make clean -C ../device_trees
+	rm -rf image-builder/deploy
+	rm -rf images

--- a/image_builder/scripts/post_build.sh
+++ b/image_builder/scripts/post_build.sh
@@ -36,14 +36,14 @@ if [ ! -f "MLO" ]; then
   exit 1
 fi
 
-cp -v MLO "${target_dir}"
+mv -v MLO "${target_dir}"
 
 if [ ! -f "u-boot-dtb.img" ]; then
   echo "ERROR: (post-build) u-boot-dtb.img missing"
   exit 1
 fi
 
-cp -v u-boot-dtb.img "${target_dir}"
+mv -v u-boot-dtb.img "${target_dir}"
 
 echo "Log: (post-build) building root fs"
 mkdir -p "${root_fs}"


### PR DESCRIPTION
Simply adds a rule so that untracked content is ignored in repos we don't own (i.e. omap image builder and beagle board device trees)