### PR TITLE
Configure CAN interfaces for 1Mbps

### DIFF
--- a/image_builder/chroot_scripts/oresat-chroot.sh
+++ b/image_builder/chroot_scripts/oresat-chroot.sh
@@ -190,6 +190,14 @@ DHCP=yes
 MulticastDNS=yes
 __EOF__
 
+cat <<__EOF__ >"/ect/systemd/network/10-can.network"
+[Match]
+Name=can*
+
+[CAN]
+BitRate=1M
+__EOF__
+
 # make sure these are enabled
 systemctl enable systemd-networkd.service
 # systemctl enable systemd-resolved.service


### PR DESCRIPTION

This configuration will allow networkd to configure all can interfaces to use a 1Mbps bitrate.

See [systemd.network manual CAN Options section](https://man.archlinux.org/man/systemd.network.5#%5BCAN%5D_SECTION_OPTIONS) for more information.
